### PR TITLE
Refactor explicit

### DIFF
--- a/src/picai_prep/archive.py
+++ b/src/picai_prep/archive.py
@@ -14,18 +14,14 @@
 
 
 import datetime
-import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from dataclasses import InitVar, dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Union
-
-import jsonschema
+from typing import Dict, Optional
 
 from picai_prep.data_utils import PathLike
-from picai_prep.utilities import lower_strip, metadata_defaults, plural
+from picai_prep.utilities import plural
 
 
 class ArchiveConverter(ABC):

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -380,9 +380,9 @@ class Dicom2MHAConverter:
         self.cases = self._init_cases(dcm2mha_settings.get('archive', {}))
 
         logfile = self.output_dir / f'picai_prep_{datetime.now().strftime("%Y%m%d%H%M%S")}.log'
-        logging.basicConfig(filemode='w', level=logging.INFO, format='%(message)s', filename=logfile)
+        logging.basicConfig(level=logging.INFO, format='%(message)s', filename=logfile)
         logging.info(f'Output directory set to {self.output_dir.absolute().as_posix()}')
-        print(f'Writing log to {logfile}')
+        print(f'Writing log to {logfile.absolute()}')
 
     def _init_cases(self, archive: List[Dict]) -> List[Dicom2MHACase]:
         cases = {}

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -372,8 +372,8 @@ class Dicom2MHAConverter:
 
         jsonschema.validate(dcm2mha_settings, dcm2mha_schema, cls=jsonschema.Draft7Validator)
 
-        self.settings = Dicom2MHASettings(dcm2mha_settings.get('mappings', {}), **dcm2mha_settings.get('options', {}))
-        self.cases = self._init_cases(dcm2mha_settings.get('archive', {}), settings=self.settings)
+        self.settings = Dicom2MHASettings(dcm2mha_settings['mappings'], **dcm2mha_settings.get('options', {}))
+        self.cases = self._init_cases(dcm2mha_settings['archive'], settings=self.settings)
 
         logfile = self.output_dir / f'picai_prep_{datetime.now().strftime("%Y%m%d%H%M%S")}.log'
         logging.basicConfig(level=logging.INFO, format='%(message)s', filename=logfile)

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -320,9 +320,6 @@ class Dicom2MHACase(Case):
                                 serie.write_log(f'Removed by {name} tiebreaker from "{mapping}"')
                                 series.remove(serie)
 
-                # after tiebreakers there should not be more than one item left
-                assert len(series) <= 1, f'More than one serie left for mapping "{mapping}"'
-
     def process_and_write(self, output_dir: Path):
         total = sum([len(serie.mappings) for serie in self.valid_series])
         self.write_log(f'Writing {plural(total, "serie")}')

--- a/src/picai_prep/examples/dcm2mha/sample_archive.py
+++ b/src/picai_prep/examples/dcm2mha/sample_archive.py
@@ -16,10 +16,10 @@
 import json
 import os
 from pathlib import Path
-from tqdm import tqdm
 from typing import Dict
 
 from picai_prep.data_utils import PathLike
+from tqdm import tqdm
 
 
 def generate_dcm2mha_settings(
@@ -55,8 +55,6 @@ def generate_dcm2mha_settings(
         explicitly verify dicom filenames as a sanity check
     allow_duplicates: bool, default: False
         when multiple series apply to a mapping, convert all
-    random_seed: int, optional, default: None
-        random is used as a final tiebreaker when resolving duplicates
     """
     ignore_files = [
         ".DS_Store",

--- a/tests/output-expected/dcm2mha_settings.json
+++ b/tests/output-expected/dcm2mha_settings.json
@@ -1,7 +1,4 @@
 {
-    "options": {
-        "random_seed": 1
-    },
     "mappings": {
         "t2w": {
             "SeriesDescription": [

--- a/tests/test_archive_json_generation.py
+++ b/tests/test_archive_json_generation.py
@@ -34,7 +34,6 @@ def test_archive_json(
     generate_dcm2mha_settings(
         archive_dir=archive_dir,
         output_path=output_path,
-        random_seed=1
     )
 
     with open(output_path) as fp:

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -14,7 +14,6 @@
 
 
 import os
-import random
 import shutil
 
 import SimpleITK as sitk

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -15,10 +15,12 @@
 
 import os
 import shutil
+from pathlib import Path
 
 import SimpleITK as sitk
 from numpy.testing import assert_allclose
-from picai_prep.dcm2mha import Dicom2MHAConverter
+from picai_prep.dcm2mha import (Dicom2MHACase, Dicom2MHAConverter,
+                                Dicom2MHASettings)
 
 
 def test_dcm2mha(
@@ -61,3 +63,38 @@ def test_dcm2mha(
 
             # compare images
             assert_allclose(img_expected, img)
+
+
+def test_resolve_duplicates(
+    input_dir: str = "tests/input/dcm/ProstateX",
+    output_dir: str = "tests/output/mha/ProstateX",
+    output_expected_dir: str = "tests/output-expected/mha/ProstateX",
+):
+    # setup case with duplicates
+    case = Dicom2MHACase(
+        input_dir=Path(input_dir),
+        patient_id="ProstateX-0001",
+        study_id="07-08-2011",
+        paths=[
+            "ProstateX-0001/07-08-2011/10.000000-t2tsetra-17541",
+            "ProstateX-0001/07-08-2011/6.000000-t2tsetra-76610",
+        ],
+        settings=Dicom2MHASettings(
+            mappings={
+                "t2w": {
+                    "SeriesDescription": [
+                        "t2_tse_tra"
+                    ]
+                },
+            }
+        )
+    )
+
+    # resolve duplicates
+    case.extract_metadata()
+    case.apply_mappings()
+    case.resolve_duplicates()
+
+    # check if duplicates were resolved
+    matched_series = [serie for serie in case.valid_series if "t2w" in serie.mappings]
+    assert len(matched_series) == 1, 'More than one serie after resolving duplicates!'


### PR DESCRIPTION
- Make Dicom2MHASettings options explicit: this prevents misspelling parameters to cause disASTeR!1!
- Added comments where typing/docstring is missing