### PR TITLE
Refactor value matching & make user-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Using this configuration file, the [`DICOM Archive`][dicom-archive] → [`MHA Ar
 from picai_prep import Dicom2MHAConverter
 
 archive = Dicom2MHAConverter(
-    input_path="/input/path/to/dicom/archive",
-    output_path="/output/path/to/mha/archive",
-    settings_path="/path/to/dcm2mha_settings.json",
+    input_dir="/input/path/to/dicom/archive",
+    output_dir="/output/path/to/mha/archive",
+    dcm2mha_settings="/path/to/dcm2mha_settings.json",
 )
 archive.convert()
 ```

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -240,7 +240,7 @@ class Dicom2MHACase(Case):
             return self.compile_log()
 
     def extract_metadata(self):
-        self.write_log(f'Extracting metadata from {plural(self.valid_series, "serie")}')
+        self.write_log(f'Extracting metadata from {plural(len(self.valid_series), "serie")}')
         errors = []
 
         for i, serie in enumerate(self.valid_series):
@@ -256,8 +256,7 @@ class Dicom2MHACase(Case):
         self.write_log(f'\t({plural(len(errors), "error")}{f" {errors}" if len(errors) > 0 else ""})')
 
     def apply_mappings(self):
-        vseries = len(self.valid_series)
-        self.write_log(f'Applying mappings to {vseries} series')
+        self.write_log(f'Applying mappings to {len(self.valid_series)} series')
         errors = []
 
         for i, serie in enumerate(self.valid_series):

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -164,32 +164,13 @@ class Series:
         self.write_log('Extracted metadata')
 
     @staticmethod
-    def values_match(needle: str, haystack: str, lower=True, strip=True, matching="eq") -> bool:
-        """
-        Check if two values match
-
-        Parameters
-        ----------
-        - lower: case insensitive matching
-        - strip: trim whitespace from edges
-        - matching: eq for equality, contains for needle in haystack
-
-        Returns
-        -------
-        - True if values match, False otherwise
-        """
-        if lower:
-            needle = needle.lower()
-            haystack = haystack.lower()
-        if strip:
-            needle = needle.strip()
-            haystack = haystack.strip()
-        if matching == "eq":
-            if needle == haystack:
-                return True
-        elif matching == "contains":
-            if needle in haystack:
-                return True
+    def values_match(needle: str, haystack: str, matching="eq") -> bool:
+        needle = lower_strip(needle)
+        haystack = lower_strip(haystack)
+        if matching == "eq" and needle == haystack:
+            return True
+        elif matching == "contains" and needle in haystack:
+            return True
 
         return False
 

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -125,7 +125,7 @@ class Series:
             raise MissingDICOMFilesError(self.path)
         return True
 
-    def extract_metadata(self, verify_dicom_filenames: bool = True) -> None:
+    def extract_metadata(self, tags: Dict[str, str], verify_dicom_filenames: bool = True) -> None:
         """
         Verify DICOM slices and extract metadata from the last DICOM slice
         """
@@ -144,14 +144,23 @@ class Series:
         dicom_slice_path = self.path / self.filenames[-1]
 
         try:
-            # read metadata from DICOM slice
-            ds = pydicom.dcmread(dicom_slice_path, stop_before_pixels=True)
-            self.metadata = ds.to_json_dict()
-            self.resolution = ds.PixelSpacing
-        except pydicom.errors.InvalidDicomError:
-            e = UnreadableDICOMError(self.path)
-            self.error = e
-            logging.error(str(e))
+            file_reader.SetFileName(str(dicom_slice_path))
+            file_reader.ReadImageInformation()
+            self.resolution = np.prod(file_reader.GetSpacing())
+            for name, tag in tags.items():
+                self.metadata[name] = file_reader.GetMetaData(tag) if file_reader.HasMetaDataKey(tag) else ''
+            print(dicom_slice_path, self.metadata)
+        except Exception as e:
+            self.write_log(f"Reading with SimpleITK failed for {self.path} with error: {e}. Attempting with pydicom.")
+            try:
+                with pydicom.dcmread(dicom_slice_path) as data:
+                    self.resolution = np.prod(data.PixelSpacing)
+                    for name, id in tags.items():
+                        self.metadata[name] = get_pydicom_value(data, id)
+            except pydicom.errors.InvalidDicomError:
+                e = UnreadableDICOMError(self.path)
+                self.error = e
+                logging.error(str(e))
 
         self.write_log('Extracted metadata')
 
@@ -288,6 +297,7 @@ class Dicom2MHACase(Case):
         for i, serie in enumerate(self.valid_series):
             try:
                 serie.extract_metadata(
+                    tags=self.settings.mappings,
                     verify_dicom_filenames=self.settings.verify_dicom_filenames
                 )
             except (MissingDICOMFilesError, UnreadableDICOMError) as e:

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -206,17 +206,24 @@ class Series:
             metadata_match_func = self.metadata_matches
 
         # resolve value match function
-        if values_match_func == "lower_strip_equal":
-            def values_match_func(needle, haystack):
-                return lower_strip(needle) == lower_strip(haystack)
-        elif values_match_func == "lower_strip_contains":
-            def values_match_func(needle, haystack):
-                return lower_strip(needle) in lower_strip(haystack)
-        elif values_match_func == "lower_strip_regex":
-            def values_match_func(needle, haystack):
-                return re.search(lower_strip(needle), lower_strip(haystack)) is not None
-        elif isinstance(values_match_func, str):
-            raise ValueError(f"Invalid values_match_func: {values_match_func}")
+        if isinstance(values_match_func, str):
+            variant = values_match_func
+
+            def values_match_func(needle: str, haystack: str) -> bool:
+                if "lower" in variant:
+                    needle = needle.lower()
+                    haystack = haystack.lower()
+                if "strip" in variant:
+                    needle = needle.strip()
+                    haystack = haystack.strip()
+                if "equals" in variant:
+                    return needle == haystack
+                elif "contains" in variant:
+                    return needle in haystack
+                elif "regex" in variant:
+                    return re.search(needle, haystack) is not None
+                else:
+                    raise ValueError(f'Unknown values match function variant {variant}')
 
         for name, mapping in mappings.items():
             if metadata_match_func(metadata=self.metadata, mapping=mapping, values_match_func=values_match_func):

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -125,7 +125,7 @@ class Series:
             raise MissingDICOMFilesError(self.path)
         return True
 
-    def extract_metadata(self, tags: Dict[str, str], verify_dicom_filenames: bool = True) -> None:
+    def extract_metadata(self, verify_dicom_filenames: bool = True) -> None:
         """
         Verify DICOM slices and extract metadata from the last DICOM slice
         """
@@ -144,23 +144,14 @@ class Series:
         dicom_slice_path = self.path / self.filenames[-1]
 
         try:
-            file_reader.SetFileName(str(dicom_slice_path))
-            file_reader.ReadImageInformation()
-            self.resolution = np.prod(file_reader.GetSpacing())
-            for name, tag in tags.items():
-                self.metadata[name] = file_reader.GetMetaData(tag) if file_reader.HasMetaDataKey(tag) else ''
-            print(dicom_slice_path, self.metadata)
-        except Exception as e:
-            self.write_log(f"Reading with SimpleITK failed for {self.path} with error: {e}. Attempting with pydicom.")
-            try:
-                with pydicom.dcmread(dicom_slice_path) as data:
-                    self.resolution = np.prod(data.PixelSpacing)
-                    for name, id in tags.items():
-                        self.metadata[name] = get_pydicom_value(data, id)
-            except pydicom.errors.InvalidDicomError:
-                e = UnreadableDICOMError(self.path)
-                self.error = e
-                logging.error(str(e))
+            # read metadata from DICOM slice
+            ds = pydicom.dcmread(dicom_slice_path, stop_before_pixels=True)
+            self.metadata = ds.to_json_dict()
+            self.resolution = ds.PixelSpacing
+        except pydicom.errors.InvalidDicomError:
+            e = UnreadableDICOMError(self.path)
+            self.error = e
+            logging.error(str(e))
 
         self.write_log('Extracted metadata')
 
@@ -246,7 +237,6 @@ class Dicom2MHACase(Case):
         for i, serie in enumerate(self.valid_series):
             try:
                 serie.extract_metadata(
-                    tags=self.settings.mappings,
                     verify_dicom_filenames=self.settings.verify_dicom_filenames
                 )
             except (MissingDICOMFilesError, UnreadableDICOMError) as e:

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -170,8 +170,13 @@ class Series:
 
         Parameters
         ----------
-        - lower: ignore case
+        - lower: case insensitive matching
         - strip: trim whitespace from edges
+        - matching: eq for equality, contains for needle in haystack
+
+        Returns
+        -------
+        - True if values match, False otherwise
         """
         if lower:
             needle = needle.lower()

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -197,16 +197,12 @@ class Series:
 
         for name, mapping in mappings.items():
             for key, values in mapping.items():
-                if key not in self.metadata and lower_strip(key) in dicom_tags:
-                    key = dicom_tags[lower_strip(key)]
-                if key not in self.metadata and "|" in key:
-                    key = key.replace("|", "").upper()
+                key = lower_strip(key)
                 if key not in self.metadata:
                     # metadata does not contain the information we need
                     continue
 
                 # check if allowed values match the observed value
-                print(f"Looking for {values} in {self.metadata[key]}")
                 if any(values_match_func(needle=value, haystack=self.metadata[key]) for value in values):
                     self.mappings.append(name)
 
@@ -296,7 +292,6 @@ class Dicom2MHACase(Case):
         for i, serie in enumerate(self.valid_series):
             try:
                 serie.extract_metadata(
-                    tags=self.settings.mappings,
                     verify_dicom_filenames=self.settings.verify_dicom_filenames
                 )
             except (MissingDICOMFilesError, UnreadableDICOMError) as e:

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -240,11 +240,9 @@ class Dicom2MHACase(Case):
             return self.compile_log()
 
     def extract_metadata(self):
-        vseries = len(self.valid_series)
-        self.write_log(f'Extracting metadata from {plural(vseries, "serie")}')
+        self.write_log(f'Extracting metadata from {plural(self.valid_series, "serie")}')
         errors = []
 
-        file_reader, series_reader = make_sitk_readers()
         for i, serie in enumerate(self.valid_series):
             try:
                 serie.extract_metadata(

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -125,7 +125,7 @@ class Series:
             raise MissingDICOMFilesError(self.path)
         return True
 
-    def extract_metadata(self, tags: Dict[str, str], verify_dicom_filenames: bool = True) -> None:
+    def extract_metadata(self, verify_dicom_filenames: bool = True) -> None:
         """
         Verify DICOM slices and extract metadata from the last DICOM slice
         """
@@ -147,16 +147,15 @@ class Series:
             file_reader.SetFileName(str(dicom_slice_path))
             file_reader.ReadImageInformation()
             self.resolution = np.prod(file_reader.GetSpacing())
-            for name, tag in tags.items():
-                self.metadata[name] = file_reader.GetMetaData(tag) if file_reader.HasMetaDataKey(tag) else ''
-            print(dicom_slice_path, self.metadata)
+            for name, key in dicom_tags.items():
+                self.metadata[name] = file_reader.GetMetaData(key) if file_reader.HasMetaDataKey(key) else ''
         except Exception as e:
             self.write_log(f"Reading with SimpleITK failed for {self.path} with error: {e}. Attempting with pydicom.")
             try:
                 with pydicom.dcmread(dicom_slice_path) as data:
                     self.resolution = np.prod(data.PixelSpacing)
-                    for name, id in tags.items():
-                        self.metadata[name] = get_pydicom_value(data, id)
+                    for name, key in dicom_tags.items():
+                        self.metadata[name] = get_pydicom_value(data, key)
             except pydicom.errors.InvalidDicomError:
                 e = UnreadableDICOMError(self.path)
                 self.error = e

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -14,6 +14,7 @@
 import json
 import logging
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -211,6 +212,9 @@ class Series:
         elif values_match_func == "lower_strip_contains":
             def values_match_func(needle, haystack):
                 return lower_strip(needle) in lower_strip(haystack)
+        elif values_match_func == "lower_strip_regex":
+            def values_match_func(needle, haystack):
+                return re.search(lower_strip(needle), lower_strip(haystack)) is not None
         elif isinstance(values_match_func, str):
             raise ValueError(f"Invalid values_match_func: {values_match_func}")
 

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -67,8 +67,6 @@ def test_dcm2mha(
 
 def test_resolve_duplicates(
     input_dir: str = "tests/input/dcm/ProstateX",
-    output_dir: str = "tests/output/mha/ProstateX",
-    output_expected_dir: str = "tests/output-expected/mha/ProstateX",
 ):
     # setup case with duplicates
     case = Dicom2MHACase(

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -141,16 +141,23 @@ def test_value_match_multiple_keys(
 ):
     # setup case
     series_list = os.listdir(os.path.join(input_dir, patient_id, study_id))
-    case = Dicom2MHACase(
+    paths = [
+        os.path.join(patient_id, study_id, series_id) for series_id in series_list
+        if os.path.isdir(os.path.join(input_dir, patient_id, study_id, series_id))
+    ]
+    archive = Dicom2MHAConverter(
         input_dir=Path(input_dir),
-        patient_id=patient_id,
-        study_id=study_id,
-        paths=[
-            os.path.join(patient_id, study_id, series_id) for series_id in series_list
-            if os.path.isdir(os.path.join(input_dir, patient_id, study_id, series_id))
-        ],
-        settings=Dicom2MHASettings(
-            mappings={
+        output_dir="",
+        dcm2mha_settings={
+            "archive": [
+                {
+                    "patient_id": patient_id,
+                    "study_id": study_id,
+                    "path": path
+                }
+                for path in paths
+            ],
+            "mappings": {
                 "test": {
                     "SeriesDescription": [
                         ""
@@ -160,9 +167,13 @@ def test_value_match_multiple_keys(
                     ]
                 },
             },
-            values_match_func="lower_strip_contains"
-        )
+            "options": {
+                "values_match_func": "lower_strip_contains"
+            }
+        }
     )
+
+    case = archive.cases[0]
 
     # resolve duplicates
     case.extract_metadata()


### PR DESCRIPTION
- Move responsibility of extracting a series' metadata to the Series class
- Move responsibility to match metadata to Series class
- Drop `lower_strip` outside value matching function
- Validate `mappings`, but no further processing
- Let `extract_metadata` make its own file reader
- Extract all metadata (simpler and allows custom value matching)
- Bugfix: all mappings must be satisfied, not just one!

Please see this commit to check which version you prefer for `values_match` (long & documented, or short): https://github.com/DIAGNijmegen/picai_prep/commit/48790a97f8d0cc1889dcff4d4a7c08deebe83880