### PR TITLE
Refactor cleanup

### DIFF
--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -160,14 +160,14 @@ class Series:
         try:
             file_reader.SetFileName(str(dicom_slice_path))
             file_reader.ReadImageInformation()
-            self.resolution = np.prod(file_reader.GetSpacing())
+            self.spacing = file_reader.GetSpacing()
             for name, key in dicom_tags.items():
                 self.metadata[name] = file_reader.GetMetaData(key) if file_reader.HasMetaDataKey(key) else ''
         except Exception as e:
             self.write_log(f"Reading with SimpleITK failed for {self.path} with error: {e}. Attempting with pydicom.")
             try:
                 with pydicom.dcmread(dicom_slice_path) as data:
-                    self.resolution = np.prod(data.PixelSpacing)
+                    self.spacing = data.PixelSpacing
                     for name, key in dicom_tags.items():
                         self.metadata[name] = get_pydicom_value(data, key)
             except pydicom.errors.InvalidDicomError:
@@ -358,7 +358,7 @@ class Dicom2MHACase(Case):
         # define tiebreakers, which should have: name, value_func, pick_largest
         tiebreakers = [
             ('slice count', lambda a: len(a.filenames), True),
-            ('image resolution', lambda a: a.resolution, False),
+            ('image resolution', lambda a: np.prod(a.spacing), False),
             ('filename', lambda a: str(a.path), False),
         ]
 

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -19,7 +19,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import jsonschema
 import numpy as np
@@ -102,7 +102,7 @@ class Series:
 
     # image metadata
     filenames: Optional[List[str]] = None
-    resolution: Optional[float] = None
+    spacing: Optional[Sequence[float]] = None
     metadata: Optional[Metadata] = field(default_factory=dict)
 
     mappings: List[str] = field(default_factory=list)
@@ -127,12 +127,14 @@ class Series:
         self._log.append(msg)
 
     def verify_dicom_filenames(self, filenames: List[PathLike]) -> bool:
+        """Verify DICOM filenames have increasing numbers, with no gaps"""
         vdcms = [d.rsplit('.', 1)[0] for d in filenames]
         vdcms = [int(''.join(c for c in d if c.isdigit())) for d in vdcms]
         missing_slices = False
         for num in range(min(vdcms), max(vdcms) + 1):
             if num not in vdcms:
                 missing_slices = True
+                break
         if missing_slices:
             raise MissingDICOMFilesError(self.path)
         return True

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -120,7 +120,7 @@ class Series:
             raise NotADirectoryError(self.path)
 
     @property
-    def is_valid(self):
+    def is_valid(self) -> bool:
         return self.error is None
 
     def write_log(self, msg: str):
@@ -261,7 +261,7 @@ class Dicom2MHACase(Case):
         return [item for item in self.series if item.is_valid]
 
     @property
-    def subject_id(self):
+    def subject_id(self) -> str:
         return f"{self.patient_id}_{self.study_id}"
 
     def invalidate(self):

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -111,7 +111,7 @@ class Series:
     _log: List[str] = field(default_factory=list)
 
     def __repr__(self):
-        return self.path.name
+        return f"Series({self.path.name})"
 
     def __post_init__(self):
         if not self.path.exists():


### PR DESCRIPTION
- make property for subject id
- make destination path variable descriptive
- simplify destination path definition
- documentation
- prevent very long range (e.g., if min/max num are very far apart, which is likely if numbers do not represent the DICOM slice nr.)
- make spacing property more logical, rather than the product. This makes the tiebreaker clear/easy to read.