### PR TITLE
Read dicom zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.mha filter=lfs diff=lfs merge=lfs -text
 *.nii.gz filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='2.0.2',
+        version='2.1.0',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_prep/dcm2dce.py
+++ b/src/picai_prep/dcm2dce.py
@@ -21,7 +21,7 @@ import SimpleITK as sitk
 from picai_prep.converter import Case
 from picai_prep.data_utils import PathLike, atomic_image_write
 from picai_prep.dcm2mha import (Dicom2MHACase, Dicom2MHAConverter,
-                                read_image_series)
+                                DICOMImageReader)
 from picai_prep.errors import DCESeriesNotFoundError
 
 
@@ -108,7 +108,7 @@ class Dicom2DCECase(Dicom2MHACase):
                 self.write_log(f"[{i+1}/{len(times)}]: Reading scan at {timepoint}s from {ser_dir}")
 
             # Collect T1 image of ordered time points
-            image = read_image_series(ser_dir)
+            image = DICOMImageReader(ser_dir).image
             dce_scans.append(image)
 
         joined_images: sitk.Image = sitk.JoinSeries(dce_scans)

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -458,6 +458,7 @@ class Dicom2MHAConverter(Converter):
 class DICOMImageReader:
     """
     Read folder containing DICOM slices (possibly enclosed in a 'dicom.zip' file).
+    If both DICOM slices and a 'dicom.zip' file are present, the DICOM slices are used.
 
     Parameters
     ----------

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import io
 import json
 import logging
 import os
@@ -34,8 +33,7 @@ from picai_prep.errors import (ArchiveItemPathNotFoundError,
                                CriticalErrorInSiblingError,
                                MissingDICOMFilesError, NoMappingsApplyError,
                                UnreadableDICOMError)
-from picai_prep.utilities import (dcm2mha_schema, dicom_tags,
-                                  make_sitk_readers, plural)
+from picai_prep.utilities import dcm2mha_schema, dicom_tags, plural
 
 Metadata = Dict[str, str]
 Mapping = Dict[str, List[str]]
@@ -84,60 +82,15 @@ class Series:
         if not self.path.is_dir():
             raise NotADirectoryError(self.path)
 
-    def verify_dicom_filenames(self, filenames: List[PathLike]) -> bool:
-        """Verify DICOM filenames have increasing numbers, with no gaps"""
-        vdcms = [d.rsplit('.', 1)[0] for d in filenames]
-        vdcms = [int(''.join(c for c in d if c.isdigit())) for d in vdcms]
-        missing_slices = False
-        for num in range(min(vdcms), max(vdcms) + 1):
-            if num not in vdcms:
-                missing_slices = True
-                break
-        if missing_slices:
-            raise MissingDICOMFilesError(self.path)
-        return True
-
     def extract_metadata(self, verify_dicom_filenames: bool = True) -> None:
         """
         Verify DICOM slices and extract metadata from the last DICOM slice
         """
-        file_reader, series_reader = make_sitk_readers()
-        self.filenames = [os.path.basename(dcm) for dcm in series_reader.GetGDCMSeriesFileNames(str(self.path))]
-
-        # verify DICOM files are found
-        if len(self.filenames) == 0:
-            raise MissingDICOMFilesError(self.path)
-
-        if verify_dicom_filenames:
-            # verify DICOM filenames have increasing numbers, with no gaps
-            self.verify_dicom_filenames(self.filenames)
-
-        # extract metadata from last DICOM slice
-        dicom_slice_path = self.path / self.filenames[-1]
-
-        try:
-            file_reader.SetFileName(str(dicom_slice_path))
-            file_reader.ReadImageInformation()
-            self.spacing = file_reader.GetSpacing()
-
-            for key in file_reader.GetMetaDataKeys():
-                # collect all available metadata (with DICOM tags, e.g. 0010|1010, as keys)
-                self.metadata[key] = file_reader.GetMetaData(key)
-            for name, key in dicom_tags.items():
-                # collect metadata with DICOM names, e.g. patientsage, as keys)
-                self.metadata[name] = file_reader.GetMetaData(key) if file_reader.HasMetaDataKey(key) else ''
-        except Exception as e:
-            self.write_log(f"Reading with SimpleITK failed for {self.path} with error: {e}. Attempting with pydicom.")
-            try:
-                with pydicom.dcmread(dicom_slice_path) as data:
-                    self.spacing = data.PixelSpacing
-                    for name, key in dicom_tags.items():
-                        self.metadata[name] = get_pydicom_value(data, key)
-            except pydicom.errors.InvalidDicomError:
-                e = UnreadableDICOMError(self.path)
-                self.error = e
-                logging.error(str(e))
-
+        # try:
+        reader = DICOMImageReader(self.path, verify_dicom_filenames=verify_dicom_filenames)
+        self.metadata = reader.metadata
+        self.spacing = self.metadata["spacing"]
+        self.filenames = reader.dicom_slice_paths
         self.write_log('Extracted metadata')
 
     @staticmethod
@@ -522,19 +475,22 @@ class DICOMImageReader:
     >>> metadata = reader.metadata
     """
 
-    def __init__(self, path: PathLike):
+    def __init__(self, path: PathLike, verify_dicom_filenames: bool = True):
         self.path = Path(path)
+        self.verify_dicom_filenames = verify_dicom_filenames
         self._image = None
         self._metadata = None
+        self.dicom_slice_paths: Optional[List[str]] = None
 
-        series_reader = sitk.ImageSeriesReader()
-        self.dicom_slice_paths = series_reader.GetGDCMSeriesFileNames(str(self.path))
-        if len(self.dicom_slice_paths) == 0:
+        self.series_reader = sitk.ImageSeriesReader()
+        try:
+            self._update_dicom_list()
+        except MissingDICOMFilesError:
             self.dicom_slice_paths = None
             if (self.path / "dicom.zip").exists():
                 self.path = self.path / "dicom.zip"
             else:
-                raise FileNotFoundError(f'No DICOM slices found in {self.path}')
+                raise MissingDICOMFilesError(f'No DICOM slices found in {self.path}')
 
     @property
     def image(self):
@@ -560,9 +516,20 @@ class DICOMImageReader:
         except RuntimeError:
             return self._read_image_pydicom(path=path)
 
-    def _read_metadata(self) -> Dict[str, str]:
-        if self._image is not None:
-            return {key: self.image.GetMetaData(key) for key in self.image.GetMetaDataKeys()}
+    def _update_dicom_list(self, path: Optional[PathLike] = None):
+        if path is None:
+            path = self.path
+
+        self.dicom_slice_paths = self.series_reader.GetGDCMSeriesFileNames(str(path))
+
+        # verify DICOM files are found
+        if len(self.dicom_slice_paths) == 0:
+            raise MissingDICOMFilesError(self.path)
+
+        if self.verify_dicom_filenames:
+            # verify DICOM filenames have increasing numbers, with no gaps
+            filenames = [os.path.basename(dcm) for dcm in self.dicom_slice_paths]
+            self._verify_dicom_filenames(filenames)
 
     def _read_image_sitk(self, path: Optional[PathLike] = None) -> sitk.Image:
         """
@@ -579,21 +546,17 @@ class DICOMImageReader:
         -------
         image: SimpleITK.Image
         """
-        if path is None:
-            path = self.path
-            dicom_slice_paths = self.dicom_slice_paths
-        else:
-            series_reader = sitk.ImageSeriesReader()
-            dicom_slice_paths = series_reader.GetGDCMSeriesFileNames(str(path))
+        if path is not None:
+            self.path = path
+            self._update_dicom_list(path=path)
 
         # read DICOM sequence
-        series_reader = sitk.ImageSeriesReader()
-        series_reader.SetFileNames(dicom_slice_paths)
-        image: sitk.Image = series_reader.Execute()
+        self.series_reader.SetFileNames(self.dicom_slice_paths)
+        image: sitk.Image = self.series_reader.Execute()
 
         # read metadata from the last DICOM slice
         reader = sitk.ImageFileReader()
-        reader.SetFileName(str(dicom_slice_paths[0]))
+        reader.SetFileName(self.dicom_slice_paths[0])
         reader.LoadPrivateTagsOn()
         reader.ReadImageInformation()
 
@@ -620,14 +583,11 @@ class DICOMImageReader:
         -------
         image: SimpleITK.Image
         """
-        if path is None:
-            path = self.path
-            dicom_slice_paths = self.dicom_slice_paths
-        else:
-            series_reader = sitk.ImageSeriesReader()
-            dicom_slice_paths = series_reader.GetGDCMSeriesFileNames(str(path))
+        if path is not None:
+            self.path = path
+            self._update_dicom_list(path=path)
 
-        files = [pydicom.dcmread(dcm) for dcm in dicom_slice_paths]
+        files = [pydicom.dcmread(dcm) for dcm in self.dicom_slice_paths]
 
         # skip files with no SliceLocation (eg. scout views)
         slices = filter(lambda a: hasattr(a, 'SliceLocation'), files)
@@ -671,6 +631,66 @@ class DICOMImageReader:
                 zf.extractall(tempdir)
                 return self._read_image(tempdir)
 
+    def _read_metadata(self) -> Dict[str, str]:
+        if self._image is not None:
+            return {key: self.image.GetMetaData(key) for key in self.image.GetMetaDataKeys()}
+
+        if self.path.name == "dicom.zip":
+            # read metadata from dicom.zip with pydicom
+            with zipfile.ZipFile(self.path) as zf:
+                if not zf.namelist():
+                    raise RuntimeError('dicom.zip is empty')
+
+                with zf.open(zf.namelist()[-1]) as fp:
+                    ds = pydicom.dcmread(fp)
+                    return self._collect_metadata_pydicom(ds)
+
+        # extract metadata from first/last(?) DICOM slice
+        dicom_slice_path = self.dicom_slice_paths[0]
+        return self._read_metadata_from_file(dicom_slice_path)
+
+    def _read_metadata_from_file(self, path: PathLike) -> Dict[str, str]:
+        try:
+            reader = sitk.ImageFileReader()
+            reader.SetFileName(str(path))
+            reader.LoadPrivateTagsOn()
+            reader.ReadImageInformation()
+            return self._collect_metadata_sitk(reader)
+        except Exception:
+            try:
+                with pydicom.dcmread(path, stop_before_pixels=True) as ds:
+                    return self._collect_metadata_pydicom(ds)
+            except pydicom.errors.InvalidDicomError:
+                raise UnreadableDICOMError(path)
+
+    def _collect_metadata_sitk(self, ref: Union[sitk.Image, sitk.ImageFileReader]) -> Dict[str, str]:
+        metadata = {}
+        for key in ref.GetMetaDataKeys():
+            # collect all available metadata (with DICOM tags, e.g. 0010|1010, as keys)
+            metadata[key] = ref.GetMetaData(key)
+        for name, key in dicom_tags.items():
+            # collect metadata with DICOM names, e.g. patientsage, as keys)
+            metadata[name] = ref.GetMetaData(key) if ref.HasMetaDataKey(key) else ''
+
+        metadata["spacing"] = ref.GetSpacing()
+        return metadata
+
+    def _collect_metadata_pydicom(self, ds: "pydicom.dataset.Dataset") -> Dict[str, str]:
+        metadata = {}
+        for key in ds.keys():
+            # collect all available metadata (with DICOM tags, e.g. 0010|1010, as keys)
+            value = self.get_pydicom_value(ds, key)
+            if value is not None:
+                key = str(key).replace(", ", "|").replace("(", "").replace(")", "")
+                metadata[key] = value
+        for key in dicom_tags.values():
+            # collect metadata with DICOM names, e.g. patientsage, as keys)
+            value = self.get_pydicom_value(ds, key)
+            metadata[key] = value if value is not None else ''
+
+        metadata["spacing"] = ds.PixelSpacing
+        return metadata
+
     @staticmethod
     def get_pydicom_value(ds: pydicom.dataset.Dataset, key: "Union[pydicom.tag.BaseTag, str]") -> str:
         if isinstance(key, str):
@@ -693,6 +713,18 @@ class DICOMImageReader:
     def get_orientation_tuple_sitk(self, ds: pydicom.FileDataset) -> Tuple:
         return tuple(self.get_orientation_matrix(ds).transpose().flatten())
 
+    def _verify_dicom_filenames(self, filenames: List[PathLike]) -> bool:
+        """Verify DICOM filenames have increasing numbers, with no gaps"""
+        vdcms = [d.rsplit('.', 1)[0] for d in filenames]
+        vdcms = [int(''.join(c for c in d if c.isdigit())) for d in vdcms]
+        missing_slices = False
+        for num in range(min(vdcms), max(vdcms) + 1):
+            if num not in vdcms:
+                missing_slices = True
+                break
+        if missing_slices:
+            raise MissingDICOMFilesError(self.path)
+        return True
+
     def __repr__(self):
         return f'DICOMImageReader({self.path})'
-

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -612,11 +612,6 @@ class DICOMImageReader:
             if value is not None:
                 key = str(key).replace(", ", "|").replace("(", "").replace(")", "")
                 image.SetMetaData(key, value)
-        for key in dicom_tags.values():
-            # collect metadata with DICOM names, e.g. patientsage, as keys)
-            value = self.get_pydicom_value(ref, key)
-            if value is not None:
-                image.SetMetaData(key, value)
 
         return image
 

--- a/src/picai_prep/mha2nnunet.py
+++ b/src/picai_prep/mha2nnunet.py
@@ -166,7 +166,7 @@ class MHA2nnUNetConverter(Converter):
             dirname to store annotation output, will be a direct descendant of `output_dir`.
         mha2nnunet_settings: Union[PathLike, Dict]
             object with cases, nnUNet-shaped dataset.json and optional parameters.
-            May be a dictionary containing mappings, dataset.json, and optionally options, 
+            May be a dictionary containing mappings, dataset.json, and optionally options,
             or a path to a JSON file with these elements.
             - dataset_json: see nnU-Net's dataset conversion on details for the dataset.json file:
                 https://github.com/MIC-DKFZ/nnUNet/blob/master/documentation/dataset_conversion.md

--- a/src/picai_prep/utilities.py
+++ b/src/picai_prep/utilities.py
@@ -26,7 +26,6 @@ def plural(num: int, word: str):
     return f"{num} {word}{'' if num == 1 else 's'}"
 
 
-
 def make_sitk_readers() -> Tuple[sitk.ImageFileReader, sitk.ImageSeriesReader]:
     """Initialise SimpleITK series and file readers"""
     series_reader = sitk.ImageSeriesReader()

--- a/src/picai_prep/utilities.py
+++ b/src/picai_prep/utilities.py
@@ -15,7 +15,6 @@
 
 from typing import Tuple
 
-import pydicom
 import SimpleITK as sitk
 
 from picai_prep.resources.dcm2mha_schema import dcm2mha_schema
@@ -26,13 +25,6 @@ from picai_prep.resources.mha2nnunet_schema import mha2nnunet_schema
 def plural(num: int, word: str):
     return f"{num} {word}{'' if num == 1 else 's'}"
 
-
-def get_pydicom_value(data: pydicom.dataset.Dataset, key: str):
-    key = '0x' + key.replace('|', '')
-    if key in data:
-        result = data[key]
-        return result.value if not result.is_empty else None
-    return None
 
 
 def make_sitk_readers() -> Tuple[sitk.ImageFileReader, sitk.ImageSeriesReader]:

--- a/tests/Development-README.md
+++ b/tests/Development-README.md
@@ -29,5 +29,5 @@ AutoPEP8 for formatting (this can be done automatically on save, see e.g. https:
 # Push release to PyPI
 1. Increase version in setup.py, and set below
 2. Build: `python -m build`
-3. Test package distribution: `python -m twine upload --repository testpypi dist/*2.0.0*`
-4. Distribute package to PyPI: `python -m twine upload dist/*2.0.0*`
+3. Test package distribution: `python -m twine upload --repository testpypi dist/*2.1.0*`
+4. Distribute package to PyPI: `python -m twine upload dist/*2.1.0*`

--- a/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/1.000000-t2localizer-75055/dicom.zip
+++ b/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/1.000000-t2localizer-75055/dicom.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c6f094964e35b6b5976d5c102ea2d6d9a76c827f48e83b6c95fca25a02bcfee
+size 870336

--- a/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/10.000000-t2tsetra-17541/dicom.zip
+++ b/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/10.000000-t2tsetra-17541/dicom.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82d772cc93c7886d27a2ca20ecc064ce58b54c2ac35654b5ee9ffc6b98e29dd0
+size 3701037

--- a/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/11.000000-tfl3d PD reftra1.5x1.5t3-77124/dicom.zip
+++ b/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/11.000000-tfl3d PD reftra1.5x1.5t3-77124/dicom.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f3fb445eb996a2eee4f4f784f2f65639c234771cf3ef1597d4ba41d3ec72776
+size 399898

--- a/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/8.000000-ep2ddifftraDYNDISTMIXADC-33954/dicom.zip
+++ b/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/8.000000-ep2ddifftraDYNDISTMIXADC-33954/dicom.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30fcd8af0dd588eb72104d651ba63246bb7063e6af1235c14aae36072960d9c5
+size 197998

--- a/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/corrupt-sequence/dicom.zip
+++ b/tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/corrupt-sequence/dicom.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2639724d830c041d4cff750e064893a8adf38aec464397902c68801587a2864f
+size 189562

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -305,4 +305,3 @@ def test_image_reader_dicom_zip(input_dir: str):
 ])
 def test_image_reader_dicom_zip_invalid_sequence(input_dir: str):
     test_image_reader_dicom_zip(input_dir)
-

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -273,5 +273,36 @@ def test_image_reader_invalid_sequence(input_dir: str):
     test_image_reader(input_dir)
 
 
-if __name__ == "__main__":
-    test_image_reader("tests/input/dcm/ProstateX/ProstateX-0000/07-07-2011/4.000000-t2tsetra-00702")
+@pytest.mark.parametrize("input_dir", [
+    "tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/8.000000-ep2ddifftraDYNDISTMIXADC-33954",
+    "tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/11.000000-tfl3d PD reftra1.5x1.5t3-77124",
+])
+def test_image_reader_dicom_zip(input_dir: str):
+    reader1 = DICOMImageReader(path=input_dir)
+    reader2 = DICOMImageReader(path=input_dir)
+
+    # read image, then metadata
+    image1 = reader1.image
+    metadata1 = reader1.metadata
+
+    # read metadata, then image
+    metadata2 = reader2.metadata
+    image2 = reader2.image
+
+    # compare voxel values
+    assert_allclose(sitk.GetArrayFromImage(image1), sitk.GetArrayFromImage(image2))
+
+    # compare metadata
+    keys = set(metadata1.keys()) & set(metadata2.keys())
+    assert len(keys) > 1, 'No metadata found!'
+    assert {k: metadata1[k].strip() for k in keys} == {k: metadata2[k].strip() for k in keys}
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("input_dir", [
+    "tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/1.000000-t2localizer-75055",
+    "tests/input/dcm/ProstateX-dicom-zip/ProstateX-0001/07-08-2011/corrupt-sequence",
+])
+def test_image_reader_dicom_zip_invalid_sequence(input_dir: str):
+    test_image_reader_dicom_zip(input_dir)
+

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -258,8 +258,8 @@ def test_image_reader(input_dir: str):
     assert_allclose(image_sitk.GetDirection(), image_pydicom.GetDirection(), atol=1e-6)
 
     # compare metadata
-    metadata_sitk = {key: image_sitk.GetMetaData(key).strip() for key in image_sitk.GetMetaDataKeys()}
-    metadata_pydicom = {key: image_pydicom.GetMetaData(key).strip() for key in image_pydicom.GetMetaDataKeys()}
+    metadata_sitk = {key: image_sitk.GetMetaData(key) for key in image_sitk.GetMetaDataKeys()}
+    metadata_pydicom = {key: image_pydicom.GetMetaData(key) for key in image_pydicom.GetMetaDataKeys()}
     keys = set(metadata_pydicom.keys()) & set(metadata_sitk.keys())
     assert len(keys) > 1, 'No metadata found!'
     assert {k: metadata_sitk[k] for k in keys} == {k: metadata_pydicom[k] for k in keys}
@@ -295,7 +295,7 @@ def test_image_reader_dicom_zip(input_dir: str):
     # compare metadata
     keys = set(metadata1.keys()) & set(metadata2.keys())
     assert len(keys) > 1, 'No metadata found!'
-    assert {k: metadata1[k].strip() for k in keys} == {k: metadata2[k].strip() for k in keys}
+    assert {k: metadata1[k] for k in keys} == {k: metadata2[k] for k in keys}
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
Implemented new DICOMImageReader to organise DICOM reading:
- Read DICOM data from a folder or dicom.zip
- Improve support with pydicom: image origin and direction are now set correctly
- Fix metadata reading with pydicom: metadata is now read in the same way as SimpleITK
- Cleanup: split image reading with SimpleITK/pydicom to separate functions. Move pydicom-specific function `get_pydicom_value` to `dcm2mha.py`.
- Update slice from which metadata is read to align with pydicom (now orientation etc. is read from the same slice as the metadata, which is better consistency anyway)
- Added unit tests to verify image reading with SimpleITK and pydicom

Add metadata reading to DICOMImageReader:
- metadata can now be read without extracting anything from the dicom.zip
- bring the responsibility for checking DICOM filenames to DICOMImageReader
- added tests for reading from dicom.zip