### PR TITLE
Improve robustness

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='2.1.0',
+        version='2.1.1',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -458,7 +458,7 @@ class Dicom2MHAConverter(Converter):
 class DICOMImageReader:
     """
     Read folder containing DICOM slices (possibly enclosed in a 'dicom.zip' file).
-    If both DICOM slices and a 'dicom.zip' file are present, the DICOM slices are used.
+    If both DICOM slices and a 'dicom.zip' file are present, the dicom.zip used.
 
     Parameters
     ----------
@@ -485,14 +485,11 @@ class DICOMImageReader:
         self.dicom_slice_paths: Optional[List[str]] = None
 
         self.series_reader = sitk.ImageSeriesReader()
-        try:
-            self._update_dicom_list()
-        except MissingDICOMFilesError:
+        if (self.path / "dicom.zip").exists():
             self.dicom_slice_paths = None
-            if (self.path / "dicom.zip").exists():
-                self.path = self.path / "dicom.zip"
-            else:
-                raise MissingDICOMFilesError(f'No DICOM slices found in {self.path}')
+            self.path = self.path / "dicom.zip"
+        else:
+            self._update_dicom_list()
 
     @property
     def image(self):

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -485,8 +485,14 @@ class DICOMImageReader:
 
         self.series_reader = sitk.ImageSeriesReader()
         if (self.path / "dicom.zip").exists():
-            self.dicom_slice_paths = None
             self.path = self.path / "dicom.zip"
+            with zipfile.ZipFile(self.path, "r") as zf:
+                self.dicom_slice_paths = [
+                    self.path / name
+                    for name in zf.namelist()
+                    if name.endswith(".dcm")
+                ]
+            self._verify_dicom_filenames(self.dicom_slice_paths)
         else:
             self._update_dicom_list()
 

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -626,7 +626,7 @@ class DICOMImageReader:
 
     def _read_metadata(self) -> Dict[str, str]:
         if self._image is not None:
-            return {key: self.image.GetMetaData(key).strip() for key in self.image.GetMetaDataKeys()}
+            return self._collect_metadata_sitk(self._image)
 
         if self.path.name == "dicom.zip":
             # read metadata from dicom.zip with pydicom

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import io
 import json
 import logging
 import os

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -635,8 +635,9 @@ class DICOMImageReader:
                 if not zf.namelist():
                     raise RuntimeError('dicom.zip is empty')
 
-                ds = pydicom.dcmread(io.BytesIO(zf.read(zf.namelist()[-1])))
-                return self._collect_metadata_pydicom(ds)
+                with tempfile.TemporaryDirectory() as tempdir:
+                    targetpath = zf.extract(member=zf.namelist()[-1], path=tempdir)
+                    return self._read_metadata_from_file(targetpath)
 
         # extract metadata from first/last(?) DICOM slice
         dicom_slice_path = self.dicom_slice_paths[0]

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -492,7 +492,7 @@ class DICOMImageReader:
                     for name in zf.namelist()
                     if name.endswith(".dcm")
                 ]
-            self._verify_dicom_filenames(self.dicom_slice_paths)
+            self._verify_dicom_filenames()
         else:
             self._update_dicom_list()
 
@@ -532,8 +532,7 @@ class DICOMImageReader:
 
         if self.verify_dicom_filenames:
             # verify DICOM filenames have increasing numbers, with no gaps
-            filenames = [os.path.basename(dcm) for dcm in self.dicom_slice_paths]
-            self._verify_dicom_filenames(filenames)
+            self._verify_dicom_filenames()
 
     def _read_image_sitk(self, path: Optional[PathLike] = None) -> sitk.Image:
         """
@@ -712,8 +711,11 @@ class DICOMImageReader:
     def get_orientation_tuple_sitk(self, ds: pydicom.FileDataset) -> Tuple:
         return tuple(self.get_orientation_matrix(ds).transpose().flatten())
 
-    def _verify_dicom_filenames(self, filenames: List[PathLike]) -> bool:
+    def _verify_dicom_filenames(self, filenames: Optional[List[PathLike]] = None) -> bool:
         """Verify DICOM filenames have increasing numbers, with no gaps"""
+        if filenames is None:
+            filenames = [os.path.basename(dcm) for dcm in self.dicom_slice_paths]
+
         vdcms = [d.rsplit('.', 1)[0] for d in filenames]
         vdcms = [int(''.join(c for c in d if c.isdigit())) for d in vdcms]
         missing_slices = False


### PR DESCRIPTION
- Read metadata more reliably
- Cleanup terminal output, by prioritizing dicom.zip
- Cleanup spacing naming & ensure in-plane resolution