### PR TITLE
Cross-platform consistency with Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   - push
   - pull_request
+  - workflow_dispatch 
 
 jobs:
   test:
@@ -10,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.6', '3.10']
+        python-version: ['3.7', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
 testpaths = [
     "tests",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,10 +8,10 @@ platforms = unix, linux, osx, cygwin, win32
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages =
@@ -26,7 +26,7 @@ install_requires =
     scipy
     SimpleITK
     tqdm
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir =
     =src
 zip_safe = no

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='2.1.2',
+        version='2.1.3',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_prep/converter.py
+++ b/src/picai_prep/converter.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -45,6 +46,7 @@ class Case(ABC):
 
     def invalidate(self, error: Exception):
         self.error = error
+        self.error_trace = traceback.format_exc()
 
     def write_log(self, msg: str):
         self._log.append(msg)

--- a/src/picai_prep/data_utils.py
+++ b/src/picai_prep/data_utils.py
@@ -52,10 +52,10 @@ def atomic_image_write(
         dst_path_bak = path.with_name(f"backup_{path.name}")
         if dst_path_bak.exists():
             raise FileExistsError(f"Existing backup file found at {dst_path_bak}.")
-        os.rename(path, dst_path_bak)
+        os.replace(path, dst_path_bak)
 
     # rename temporary file
-    os.rename(path_tmp, path)
+    os.replace(path_tmp, path)
 
 
 def atomic_file_copy(
@@ -89,7 +89,7 @@ def atomic_file_copy(
         dst_path_bak = dst_path.with_name(f"backup.{dst_path.name}")
         if dst_path_bak.exists():
             raise FileExistsError(f"Existing backup file found at {dst_path_bak}.")
-        os.rename(dst_path, dst_path_bak)
+        os.replace(dst_path, dst_path_bak)
 
     # rename temporary file
-    os.rename(dst_path_tmp, dst_path)
+    os.replace(dst_path_tmp, dst_path)

--- a/src/picai_prep/mha2nnunet.py
+++ b/src/picai_prep/mha2nnunet.py
@@ -128,14 +128,30 @@ class MHA2nnUNetCase(Case, _MHA2nnUNetCaseBase):
 
     def compile_log(self):
         if self.settings.verbose == 0:
+            # logging is disabled
             return None
 
-        if self.is_valid or self.settings.verbose >= 2:
+        if self.is_valid:
+            if self.settings.verbose >= 2:
+                # conversion was successful and verbose logging is enabled
+                return '\n'.join(['=' * 120,
+                                  f'CASE {self.subject_id}',
+                                  f'\tPATIENT ID\t{self.patient_id}',
+                                  f'\tSTUDY ID\t{self.study_id}\n',
+                                  *self._log])
+            else:
+                # conversion was successful and short logging is enabled
+                return '\n'.join([f'CASE {self.subject_id} successfully converted'])
+
+        if not self.is_valid:
+            # conversion was failed, log everything
             return '\n'.join(['=' * 120,
                               f'CASE {self.subject_id}',
                               f'\tPATIENT ID\t{self.patient_id}',
                               f'\tSTUDY ID\t{self.study_id}\n',
-                              *self._log])
+                              *self._log,
+                              'Error:',
+                              self.error_trace])
 
 
 class MHA2nnUNetConverter(Converter):

--- a/src/picai_prep/preprocessing.py
+++ b/src/picai_prep/preprocessing.py
@@ -151,9 +151,9 @@ def input_verification_crop_or_pad(
             size = size_zyx
         else:
             # verify size
-            if size != size_zyx:
+            if list(size) != list(size_zyx):
                 raise ValueError(f"Size and physical size do not match. Size: {size}, physical size: "
-                                 f"{physical_size}, spacing: {spacing_zyx}")
+                                 f"{physical_size}, spacing: {spacing_zyx}, size_zyx: {size_zyx}.")
 
     if isinstance(image, sitk.Image):
         # determine shape and convert convention of (z, y, x) to (x, y, z) for SimpleITK

--- a/tests/test_dcm2mha.py
+++ b/tests/test_dcm2mha.py
@@ -16,11 +16,13 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 import SimpleITK as sitk
 from numpy.testing import assert_allclose
+
 from picai_prep.dcm2mha import (Dicom2MHACase, Dicom2MHAConverter,
                                 Dicom2MHASettings, DICOMImageReader)
 from picai_prep.examples.dcm2mha.sample_archive import \
@@ -91,7 +93,7 @@ def test_dcm2mha_commandline(
     ]
 
     # run command
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, shell=(sys.platform == 'win32'))
 
     # compare output
     for patient_id, subject_id in [

--- a/tests/test_mha2nnunet.py
+++ b/tests/test_mha2nnunet.py
@@ -14,6 +14,7 @@
 
 
 import json
+import sys
 import os
 import shutil
 import subprocess
@@ -162,7 +163,7 @@ def test_mha2nnunet_commandline(
     ]
 
     # run command
-    subprocess.check_call(cmd)
+    subprocess.run(cmd, shell=sys.platform == 'win32').check_returncode()
 
     # check dataset.json
     path_out = task_dir / "dataset.json"

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
-minversion = 3.8.0
-envlist = py36, py37, py38, py39, flake8
+minversion = 3.7.0
+envlist = py37, py310, flake8
 isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
-    3.8: py38
-    3.9: py39, flake8
+    3.10: py310, flake8
 
 [testenv]
 setenv =
@@ -19,12 +17,12 @@ commands =
     pytest --basetemp={envtmpdir}
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.10
 deps = flake8
 commands = flake8 src tests
 
 [testenv:mypy]
-basepython = python3.9
+basepython = python3.10
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands = mypy src


### PR DESCRIPTION
On POSIX systems, the rename system call will silently replace the destination file if the user has sufficient permissions. The same is not true on Windows.

os.replace and os.rename are the same function on POSIX systems, but on Windows os.replace will call MoveFileExW with the MOVEFILE_REPLACE_EXISTING flag set to give the same effect as on POSIX systems.