### PR TITLE
Atomic operations consistency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='2.1.2',
+        version='2.1.3',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_prep/data_utils.py
+++ b/src/picai_prep/data_utils.py
@@ -52,10 +52,10 @@ def atomic_image_write(
         dst_path_bak = path.with_name(f"backup_{path.name}")
         if dst_path_bak.exists():
             raise FileExistsError(f"Existing backup file found at {dst_path_bak}.")
-        os.rename(path, dst_path_bak)
+        os.replace(path, dst_path_bak)
 
     # rename temporary file
-    os.rename(path_tmp, path)
+    os.replace(path_tmp, path)
 
 
 def atomic_file_copy(
@@ -89,7 +89,7 @@ def atomic_file_copy(
         dst_path_bak = dst_path.with_name(f"backup.{dst_path.name}")
         if dst_path_bak.exists():
             raise FileExistsError(f"Existing backup file found at {dst_path_bak}.")
-        os.rename(dst_path, dst_path_bak)
+        os.replace(dst_path, dst_path_bak)
 
     # rename temporary file
-    os.rename(dst_path_tmp, dst_path)
+    os.replace(dst_path_tmp, dst_path)


### PR DESCRIPTION
On POSIX systems, the rename system call will silently replace the destination file if the user has sufficient permissions. The same is not true on Windows.

os.replace and os.rename are the same function on POSIX systems, but on Windows os.replace will call MoveFileExW with the MOVEFILE_REPLACE_EXISTING flag set to give the same effect as on POSIX systems.