### PR TITLE
dcm2mha: remove localizer slices, improve logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='2.1.3',
+        version='2.1.4',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import tempfile
+import traceback
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -296,7 +297,10 @@ class Dicom2MHACase(Case, _Dicom2MHACaseBase):
                 except Exception as e:
                     serie.write_log(
                         f'Skipped "{mapping}", reading DICOM sequence failed, maybe corrupt data? Error: {e}')
-                    logging.error(str(e))
+                    if self.settings.verbose >= 2:
+                        logging.error(traceback.format_exc())
+                    else:
+                        logging.error(str(e))
                     errors.append(i)
                 else:
                     if self.settings.scan_postprocess_func is not None:

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -568,9 +568,6 @@ class DICOMImageReader:
 
         self.dicom_slice_paths = self.series_reader.GetGDCMSeriesFileNames(str(path))
 
-        if filter_localizer_slices:
-            self.dicom_slice_paths = self._filter_localizer_slices(self.dicom_slice_paths)
-
         # verify DICOM files are found
         if len(self.dicom_slice_paths) == 0:
             raise MissingDICOMFilesError(self.path)
@@ -578,7 +575,16 @@ class DICOMImageReader:
         if self.verify_dicom_filenames:
             self._verify_dicom_filenames()
 
-    def _read_image_sitk(self, path: Optional[PathLike] = None, filter_localizer_slices: bool = False) -> sitk.Image:
+        if filter_localizer_slices:
+            # filter out localizer slices (these are sometimes included with the DIOCM slices of the scan)
+            # note: filter out after verifying filenames.
+            self.dicom_slice_paths = self._filter_localizer_slices(self.dicom_slice_paths)
+
+    def _read_image_sitk(
+        self,
+        path: Optional[PathLike] = None,
+        filter_localizer_slices: bool = False
+    ) -> sitk.Image:
         """
         Read image using SimpleITK.
 

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -576,7 +576,7 @@ class DICOMImageReader:
             self._verify_dicom_filenames()
 
         if filter_localizer_slices:
-            # filter out localizer slices (these are sometimes included with the DIOCM slices of the scan)
+            # filter out localizer slices (these are sometimes included with the DICOM slices of the scan)
             # note: filter out after verifying filenames.
             self.dicom_slice_paths = self._filter_localizer_slices(self.dicom_slice_paths)
 

--- a/src/picai_prep/dcm2mha.py
+++ b/src/picai_prep/dcm2mha.py
@@ -672,6 +672,7 @@ class DICOMImageReader:
             metadata[name] = ref.GetMetaData(key).strip() if ref.HasMetaDataKey(key) else ''
 
         metadata["spacing_inplane"] = ref.GetSpacing()[0:2]
+        metadata["image_direction"] = ref.GetDirection()
         return metadata
 
     def _collect_metadata_pydicom(self, ds: "pydicom.dataset.Dataset") -> Dict[str, str]:


### PR DESCRIPTION
- Remove localizer slices (these can be part of the main imaging study)
- Improve logging for dcm2mha: full traceback of errors
- Expose the image orientation from SimpleITK in the metadata (to allow custom mappings with this information)