### PR TITLE
Configurable resampling interpolator

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
-flake8==3.9.2
-tox==3.24.3
-pytest==6.2.5
-pytest-cov==2.12.1
-mypy===0.910
-build
-twine
+flake8==7.1.1
+tox==4.18.1
+pytest==8.3.2
+pytest-cov==5.0.0
+mypy===1.11.2
+build==1.2.2
+twine==5.1.1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='2.1.8',
+        version='2.1.9',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_prep/preprocessing.py
+++ b/src/picai_prep/preprocessing.py
@@ -44,8 +44,8 @@ class PreprocessingSettings():
     physical_size: Optional[Iterable[float]] = None
     crop_only: bool = False
     align_segmentation: Optional[sitk.Image] = None
-    scan_interpolator = sitk.sitkBSpline
-    lbl_interpolator = sitk.sitkNearestNeighbor
+    scan_interpolator: int = sitk.sitkBSpline
+    lbl_interpolator: int = sitk.sitkNearestNeighbor
 
     def __post_init__(self):
         if self.physical_size is None and self.spacing is not None and self.matrix_size is not None:


### PR DESCRIPTION
Allow setting the resampling interpolator for preprocessing.

Dependency updates:
* [`requirements_dev.txt`](diffhunk://#diff-c9c796259f3852b51b531b79cbf07820145088d4f108fb006ab44b15f0b15934L1-R7): Updated versions of `flake8`, `tox`, `pytest`, `pytest-cov`, `mypy`, `build`, and `twine`.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L8-R8): Incremented the version number from `2.1.8` to `2.1.9`.

Interpolation settings:
* [`src/picai_prep/preprocessing.py`](diffhunk://#diff-f6c4c6e211631a6dba78bcca09d032a3147c3d8b4949bdca958e80dee0b93833R39-R48): Added `scan_interpolator` and `lbl_interpolator` attributes to the `PreprocessingSettings` class.
* [`src/picai_prep/preprocessing.py`](diffhunk://#diff-f6c4c6e211631a6dba78bcca09d032a3147c3d8b4949bdca958e80dee0b93833R80): Modified the `resample_img` function to accept an `interpolation` parameter and use it if provided. [[1]](diffhunk://#diff-f6c4c6e211631a6dba78bcca09d032a3147c3d8b4949bdca958e80dee0b93833R80) [[2]](diffhunk://#diff-f6c4c6e211631a6dba78bcca09d032a3147c3d8b4949bdca958e80dee0b93833L110-R117)
* [`src/picai_prep/preprocessing.py`](diffhunk://#diff-f6c4c6e211631a6dba78bcca09d032a3147c3d8b4949bdca958e80dee0b93833L257-R270): Updated the `resample_to_first_scan` and `resample_spacing` methods to use the new interpolation settings from `PreprocessingSettings`. [[1]](diffhunk://#diff-f6c4c6e211631a6dba78bcca09d032a3147c3d8b4949bdca958e80dee0b93833L257-R270) [[2]](diffhunk://#diff-f6c4c6e211631a6dba78bcca09d032a3147c3d8b4949bdca958e80dee0b93833L275-R288)